### PR TITLE
Fix/Stage select blank

### DIFF
--- a/src/components/smallComponents/StageSelect.jsx
+++ b/src/components/smallComponents/StageSelect.jsx
@@ -241,7 +241,7 @@ const StageSelect = ({ allStages, stage, rowMetatable, change, isCampus }) => {
       nextStage[
         getKeyByValue(
           allStages,
-          isCampus ? stage?.stage || 'enrolmentKeyGenerated' : stage
+          isCampus ? stage?.stage || "enrolmentKeyGenerated" : stage
         )
       ] || []
     ).map((x) => ({

--- a/src/components/smallComponents/StageSelect.jsx
+++ b/src/components/smallComponents/StageSelect.jsx
@@ -237,12 +237,14 @@ const StageSelect = ({ allStages, stage, rowMetatable, change, isCampus }) => {
   // }
 
   if (stage) {
-    allStagesOptions = nextStage[
-      getKeyByValue(
-        allStages,
-        isCampus ? stage?.stage || "enrolmentKeyGenerated" : stage
-      )
-    ].map((x) => ({
+    allStagesOptions = (
+      nextStage[
+        getKeyByValue(
+          allStages,
+          isCampus ? stage?.stage || 'enrolmentKeyGenerated' : stage
+        )
+      ] || []
+    ).map((x) => ({
       value: x,
       label: allStages[x],
     }));

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -280,6 +280,7 @@ export const campusStageOfLearning = {
 };
 
 export const nextStage = {
+  diversityBasedDecisionPending: [],
   enrolmentKeyGenerated: ["basicDetailsEntered"],
   createdStudentWithoutExam: [],
   basicDetailsEntered: ["pendingEnglishInterview", "testFailed"],


### PR DESCRIPTION
**Which issue does this refer to ?**
Admissions Dashboard goes blank when student has stage that's not present as a key in `nextStages`, (e.g., `diversityBasedDecisionPending`) because it tries to call `map` on the value, which would be `undefined`.

**Brief description of the changes done**
A brief step by step changes made. Example :
1. Used an empty Array when the key isn't present.
2. Added missing `diversityBasedDecisionPending` key.

**People to loop in / review from**
@its-nasir @Poonam-Singh-Bagh 